### PR TITLE
Detect only well formed URLs by running them against a valid URL regex

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,36 @@
+export const REGEX_VALID_URL = new RegExp(
+  "^" +
+    // protocol identifier
+    "(?:(?:https?|ftp)://)" +
+    // user:pass authentication
+    "(?:\\S+(?::\\S*)?@)?" +
+    "(?:" +
+      // IP address exclusion
+      // private & local networks
+      "(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
+      "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
+      "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
+      // IP address dotted notation octets
+      // excludes loopback network 0.0.0.0
+      // excludes reserved space >= 224.0.0.0
+      // excludes network & broacast addresses
+      // (first & last IP address of each class)
+      "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+      "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+      "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+    "|" +
+      // host name
+      "(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)" +
+      // domain name
+      "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*" +
+      // TLD identifier
+      "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" +
+      // TLD may end with dot
+      "\\.?" +
+    ")" +
+    // port number
+    "(?::\\d{2,5})?" +
+    // resource path
+    "(?:[/?#]\\S*)?" +
+  "$", "i"
+)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 const cheerio = require('cheerio-without-node-native');
 const Autolinker = require('autolinker');
+import {REGEX_VALID_URL} from './constants'
 
 export default class LinkPreview {
   static getPreview(text) {
@@ -18,6 +19,10 @@ export default class LinkPreview {
         replaceFn: match => {
           switch (match.getType()) {
           case 'url' :
+            const url = match.getUrl()
+            if (! REGEX_VALID_URL.test(url)) {
+            	return false
+            }
             if (!detectedUrl) { detectedUrl = match.getUrl(); }
             return true;
           default:


### PR DESCRIPTION
To reproduce the issue that prompted this pull request, try including a URL preceded immediately by a character. For example,

> ahttps://blog.glycoleap.com/herbal-chicken-brown-rice-congee-ultimate-asian-healing-food/

Notice the `a` before the URL. But Autolinker's URL parsing doesn't seem to be perfect and so, it treats the whole string as a URL and if you call `match.getUrl()`, it also adds the protocol before it. This leads to `http://stackoverflow.com/questions/38099684/no-suitable-url-request-handler-found` rather than the promise being gracefully rejected.

To solve this, I add a well recognised regex `https://gist.github.com/dperini/729294` and use it to invalidate malformed URLs.
