### PR TITLE
Prefer og:title over the title

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,10 +49,10 @@ export default class LinkPreview {
   }
 
   static _getTitle(doc) {
-    let title = doc('title').text();
+    let title = doc('meta[property=\'og:title\']').attr('content');
 
     if (!title) {
-      title = doc('meta[property=\'og:title\']').attr('content');
+      title = doc('title').text();
     }
 
     return title;


### PR DESCRIPTION
This is to prevent Facebook pages from always appearing with "Comments" as a title.