### PR TITLE
remove @Override to fix compile on android react-native 0.47

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeLinkPreviewPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeLinkPreviewPackage.java
@@ -16,7 +16,6 @@ public class RNReactNativeLinkPreviewPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNReactNativeLinkPreviewModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
[createJSModules is now not required on Android from RN 0.47](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) and breaks android compile, removing override fixes this