### PR TITLE
renaming the android package name from com.reactlibrary to io.linkpreview

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="io.linkpreview">
 
 </manifest>
   

--- a/android/src/main/java/io/linkpreview/RNReactNativeLinkPreviewModule.java
+++ b/android/src/main/java/io/linkpreview/RNReactNativeLinkPreviewModule.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package io.linkpreview;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;

--- a/android/src/main/java/io/linkpreview/RNReactNativeLinkPreviewPackage.java
+++ b/android/src/main/java/io/linkpreview/RNReactNativeLinkPreviewPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package io.linkpreview;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Hi,

First of all, I would like to appreciate this library is really good for fetching meta data attached to any specific URL

Recently I have added *[react-native-thumbnail](https://github.com/phuochau/react-native-thumbnail)* library to my project, and post that I am getting exceptions while building the project

`Exception: *react-native-link-preview* & *react-native-thumbnail* share the same package name`

In order to solve, I have renamed the package name of both libraries. Please find below updated package name:

- *RN-Link-Preivew:* *com.reactlibrary* to *io.linkpreview*

Post changing the package name, Everything is working as expected on both Android and iOS Platforms

Can you please merge this request and release a new build, so that we can seamlessly use this library

*P.S:* Doing this will make sure that in future it will not have any package name conflicts with other libraries

Please let me know in case any changes or discussion is required for the same

Thanks,
Pranav