### PR TITLE
Added support for fetching favicon images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ LinkPreview.getPreview('This is a text supposed to be parsed and the first link 
 ## Options
 Additionally you can pass an options object which should add more functionality to the parsing of the link
 
-| Property Name | Result        | 
-| ------------- |:-------------:| 
+| Property Name | Result        |
+| ------------- |:-------------:|
 | imagesPropertyType  (**optional**) (ex: 'og')     | Fetches images only with the specified property, `meta[property='${imagesPropertyType}:image']` |
 
 
 ```
 LinkPreview.getPreview(
-  'https://www.youtube.com/watch?v=MejbOFk7H6c', 
+  'https://www.youtube.com/watch?v=MejbOFk7H6c',
   {
     imagesPropertyType: 'og', // fetches only open-graph images
   })
@@ -52,7 +52,8 @@ Returns
   description: "Buy the video on iTunes: https://itunes.apple.com/us/album/needing-getting-bundle-ep/id508124847 See more about the guitars at: http://www.gretschguitars.com...",
   images: ["https://i.ytimg.com/vi/MejbOFk7H6c/maxresdefault.jpg"],
   mediaType: "video",
-  videos: []
+  videos: [],
+  favicons:["https://www.youtube.com/yts/img/favicon_32-vflOogEID.png","https://www.youtube.com/yts/img/favicon_48-vflVjB_Qk.png","https://www.youtube.com/yts/img/favicon_96-vflW9Ec0w.png","https://www.youtube.com/yts/img/favicon_144-vfliLAfaB.png","https://s.ytimg.com/yts/img/favicon-vfl8qSV2F.ico"]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ const parseResponse = function(body, url, options) {
     description: getDescription(doc),
     mediaType: getMediaType(doc) || 'website',
     images: getImages(doc, url, options.imagesPropertyType),
-    videos: getVideos(doc)
+    videos: getVideos(doc),
+    favicons: getFavicons(doc, url)
   };
 };
 
@@ -180,6 +181,39 @@ const getVideos = function(doc) {
   }
 
   return videos;
+};
+
+// returns an array of URL's to favicon images
+const getFavicons = function(doc, rootUrl) {
+  let images = [],
+    nodes = [],
+    src;
+
+  const relSelectors = ['rel=icon', 'rel="shortcut icon"', 'rel=apple-touch-icon'];
+
+  relSelectors.forEach((relSelector) => {
+    // look for all icon tags
+    nodes = doc(`link[${relSelector}]`);
+
+    // collect all images from icon tags
+    if (nodes.length) {
+      nodes.each((index, node) => {
+        src = node.attribs.href;
+        if (src) {
+          src = urlObj.resolve(rootUrl, src);
+          images.push(src);
+        }
+      });
+    }
+  });
+
+  // if no icon images, use default favicon location
+  if (images.length <= 0) {
+    src = '/favicon.ico';
+    images.push(urlObj.resolve(rootUrl, src));
+  }
+
+  return images;
 };
 
 // const parseMediaResponse = function(res, contentType, url) {


### PR DESCRIPTION
Hey there,

I added support for fetching favicon images from the HTML doc.  It's added as a new property called `favicons` in the response to `LinkPreview.getPreview`.   There's a new function called getFavicons that looks for favicons in the `link rel` tags of the page.  it prioritizes `icon` first, but also looks for (in order) `shortcut icon` and `apple-touch-icon`.  If it can't find any `link rel` tags, it uses the default favicon location (`//hostname/favicon.ico`) as a back-up.

Thanks for creating and sharing this repo!  Really helping with a project I'm working on.

Thanks,
Steve
