### PR TITLE
Added different response objects depending on content type returned in HTTP response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Additionally you can pass an options object which should add more functionality 
 | imagesPropertyType  (**optional**) (ex: 'og')     | Fetches images only with the specified property, `meta[property='${imagesPropertyType}:image']` |
 
 
-```
+```javascript
 LinkPreview.getPreview(
   'https://www.youtube.com/watch?v=MejbOFk7H6c',
   {
@@ -93,7 +93,7 @@ in the HTTP response (see below for variations of response).  Rejects with an er
 }
 ```
 
-### Application URLs
+### Application URL
 ```
 {
   url: "https://assets.curtmfg.com/masterlibrary/56282/installsheet/CME_56282_INS.pdf",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # react-native-link-preview
 
-Allows to extract information from an URL or parse a text and retrieve information from the first available link.
+Allows you to extract information from a URL or parse text and retrieve information from the first available link.
 
 ## NodeJS support
 Library should now work on node environments, thanks to @uriva and @itaibs, I will not rename the library because it may cause confusion for people who try to run in a CORS protected environment (ex. google chrome), since this does not happen for RN that was the original intention of the package.
@@ -11,7 +11,7 @@ Library should now work on node environments, thanks to @uriva and @itaibs, I wi
 `$ npm install -S react-native-link-preview`
 
 ## Usage
-Library exposes just one method: getPreview, you have to pass a string (doesn't matter if it is just an URL or a piece of text that contains an URL), the library will take care of parsing it and returning the info of first valid URL info it finds.
+Library exposes just one method: getPreview, you have to pass a string (doesn't matter if it is just a URL or a piece of text that contains a URL), the library will take care of parsing it and returning the info of first valid URL info it finds.
 
 URL parsing is done via: https://gist.github.com/dperini/729294
 
@@ -44,17 +44,69 @@ LinkPreview.getPreview(
 ```
 
 
-Returns
+## Returns
+Returns a Promise that resolves with an object describing the provided link.
+The info object returned varies depending on the content type (MIME type) returned
+in the HTTP response (see below for variations of response).  Rejects with an error if response can not be parsed or if there was no URL in the text provided.
+
+### Text/HTML URL
 ```
 {
   url: "https://www.youtube.com/watch?v=MejbOFk7H6c",
   title: "OK Go - Needing/Getting - Official Video - YouTube",
   description: "Buy the video on iTunes: https://itunes.apple.com/us/album/needing-getting-bundle-ep/id508124847 See more about the guitars at: http://www.gretschguitars.com...",
   images: ["https://i.ytimg.com/vi/MejbOFk7H6c/maxresdefault.jpg"],
-  mediaType: "video",
+  mediaType: "video.other",
+  contentType: "text/html; charset=utf-8"
   videos: [],
   favicons:["https://www.youtube.com/yts/img/favicon_32-vflOogEID.png","https://www.youtube.com/yts/img/favicon_48-vflVjB_Qk.png","https://www.youtube.com/yts/img/favicon_96-vflW9Ec0w.png","https://www.youtube.com/yts/img/favicon_144-vfliLAfaB.png","https://s.ytimg.com/yts/img/favicon-vfl8qSV2F.ico"]
 }
+```
+
+### Image URL
+```
+{
+  url: "https://media.npr.org/assets/img/2018/04/27/gettyimages-656523922nunes-4bb9a194ab2986834622983bb2f8fe57728a9e5f-s1100-c15.jpg",
+  mediaType: "image",
+  contentType: "image/jpeg",
+  favicons: [ "https://media.npr.org/favicon.ico" ]
+}
+```
+
+### Audio URL
+```
+{
+  url: "https://ondemand.npr.org/anon.npr-mp3/npr/atc/2007/12/20071231_atc_13.mp3",
+  mediaType: "audio",
+  contentType: "audio/mpeg",
+  favicons: [ "https://ondemand.npr.org/favicon.ico" ]
+}
+```
+
+### Video URL
+```
+{
+  url: "https://www.w3schools.com/html/mov_bbb.mp4",
+  mediaType: "video",
+  contentType: "video/mp4",
+  favicons: [ "https://www.w3schools.com/favicon.ico" ]
+}
+```
+
+### Application URLs
+```
+{
+  url: "https://assets.curtmfg.com/masterlibrary/56282/installsheet/CME_56282_INS.pdf",
+  mediaType: "application",
+  contentType: "application/pdf",
+  favicons: [ "https://assets.curtmfg.com/favicon.ico" ]
+}
+```
+
+## Tests
+
+```
+npm test
 ```
 
 ## License

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,5 +1,5 @@
-import LinkPreview from '../index.js';
-import expect from 'expect.js';
+const LinkPreview = require('../index.js');
+const expect = require('expect.js');
 
 global.fetch = require('node-fetch');
 
@@ -16,10 +16,12 @@ describe('link preview', () => {
     expect(linkInfo.url).to.be.equal('https://www.youtube.com/watch?v=wuClZjOdT30');
     expect(linkInfo.title).to.be.equal('Geography Now! Germany');
     expect(linkInfo.description).to.be.ok();
-    expect(linkInfo.mediaType).to.be.equal('video');
+    expect(linkInfo.mediaType).to.be.equal('video.other');
     expect(linkInfo.images.length).to.be.equal(1);
     expect(linkInfo.images[0]).to.be.equal('https://i.ytimg.com/vi/wuClZjOdT30/maxresdefault.jpg');
     expect(linkInfo.videos.length).to.be.equal(0);
+    expect(linkInfo.favicons[0]).to.be.equal('https://www.youtube.com/yts/img/favicon_32-vflOogEID.png');
+    expect(linkInfo.contentType).to.be.equal('text/html; charset=utf-8');
   });
 
   it('should extract link info from just text with a URL', async () => {
@@ -34,10 +36,68 @@ describe('link preview', () => {
     expect(linkInfo.url).to.be.equal('https://www.youtube.com/watch?v=wuClZjOdT30');
     expect(linkInfo.title).to.be.equal('Geography Now! Germany');
     expect(linkInfo.description).to.be.ok();
-    expect(linkInfo.mediaType).to.be.equal('video');
+    expect(linkInfo.mediaType).to.be.equal('video.other');
     expect(linkInfo.images.length).to.be.equal(1);
     expect(linkInfo.images[0]).to.be.equal('https://i.ytimg.com/vi/wuClZjOdT30/maxresdefault.jpg');
     expect(linkInfo.videos.length).to.be.equal(0);
+    expect(linkInfo.favicons[0]).to.be.equal('https://www.youtube.com/yts/img/favicon_32-vflOogEID.png');
+    expect(linkInfo.contentType).to.be.equal('text/html; charset=utf-8');
+  });
+
+  it('should handle audio urls', async () => {
+    const linkInfo = await LinkPreview.getPreview('https://ondemand.npr.org/anon.npr-mp3/npr/atc/2007/12/20071231_atc_13.mp3');
+
+    // { url: 'https://ondemand.npr.org/anon.npr-mp3/npr/atc/2007/12/20071231_atc_13.mp3',
+    //   mediaType: 'audio',
+    //   contentType: 'audio/mpeg',
+    //   favicons: [ 'https://ondemand.npr.org/favicon.ico' ] }
+
+    expect(linkInfo.url).to.be.equal('https://ondemand.npr.org/anon.npr-mp3/npr/atc/2007/12/20071231_atc_13.mp3');
+    expect(linkInfo.mediaType).to.be.equal('audio');
+    expect(linkInfo.contentType).to.be.equal('audio/mpeg');
+    expect(linkInfo.favicons[0]).to.be.ok();
+  });
+
+  it('should handle video urls', async () => {
+    const linkInfo = await LinkPreview.getPreview('https://www.w3schools.com/html/mov_bbb.mp4');
+
+    // { url: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    //   mediaType: 'video',
+    //   contentType: 'video/mp4',
+    //   favicons: [ 'https://www.w3schools.com/favicon.ico' ] }
+
+    expect(linkInfo.url).to.be.equal('https://www.w3schools.com/html/mov_bbb.mp4');
+    expect(linkInfo.mediaType).to.be.equal('video');
+    expect(linkInfo.contentType).to.be.equal('video/mp4');
+    expect(linkInfo.favicons[0]).to.be.ok();
+  });
+
+  it('should handle image urls', async () => {
+    const linkInfo = await LinkPreview.getPreview('https://media.npr.org/assets/img/2018/04/27/gettyimages-656523922nunes-4bb9a194ab2986834622983bb2f8fe57728a9e5f-s1100-c15.jpg');
+
+    // { url: 'https://media.npr.org/assets/img/2018/04/27/gettyimages-656523922nunes-4bb9a194ab2986834622983bb2f8fe57728a9e5f-s1100-c15.jpg',
+    //   mediaType: 'image',
+    //   contentType: 'image/jpeg',
+    //   favicons: [ 'https://media.npr.org/favicon.ico' ] }
+
+    expect(linkInfo.url).to.be.equal('https://media.npr.org/assets/img/2018/04/27/gettyimages-656523922nunes-4bb9a194ab2986834622983bb2f8fe57728a9e5f-s1100-c15.jpg');
+    expect(linkInfo.mediaType).to.be.equal('image');
+    expect(linkInfo.contentType).to.be.equal('image/jpeg');
+    expect(linkInfo.favicons[0]).to.be.ok();
+  });
+
+  it('should handle application urls', async () => {
+    const linkInfo = await LinkPreview.getPreview('https://assets.curtmfg.com/masterlibrary/56282/installsheet/CME_56282_INS.pdf');
+
+    // { url: 'https://assets.curtmfg.com/masterlibrary/56282/installsheet/CME_56282_INS.pdf',
+    //  mediaType: 'application',
+    //  contentType: 'application/pdf',
+    //  favicons: [ 'https://assets.curtmfg.com/favicon.ico' ] }
+
+    expect(linkInfo.url).to.be.equal('https://assets.curtmfg.com/masterlibrary/56282/installsheet/CME_56282_INS.pdf');
+    expect(linkInfo.mediaType).to.be.equal('application');
+    expect(linkInfo.contentType).to.be.equal('application/pdf');
+    expect(linkInfo.favicons[0]).to.be.ok();
   });
 
   it('no link in text should fail gracefully', async () => {

--- a/constants.js
+++ b/constants.js
@@ -34,3 +34,13 @@ exports.REGEX_VALID_URL = new RegExp(
     "(?:[/?#]\\S*)?" +
   "$", "i"
 );
+
+exports.REGEX_CONTENT_TYPE_IMAGE = new RegExp("image\/.*", "i");
+
+exports.REGEX_CONTENT_TYPE_AUDIO = new RegExp("audio\/.*", "i");
+
+exports.REGEX_CONTENT_TYPE_VIDEO = new RegExp("video\/.*", "i");
+
+exports.REGEX_CONTENT_TYPE_TEXT = new RegExp("text\/.*", "i");
+
+exports.REGEX_CONTENT_TYPE_APPLICATION = new RegExp("application\/.*", "i");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-link-preview",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hey there,

I made some additional changes to the repo.  I added different response objects depending on the content type (MIME type) returned in the HTTP response header from fetch.  It's not 100% perfect because it's relying on an accurate content type to be returned in the response, but it's better than nothing.  This way a developer can more easily get a sense for what type of content is there if it's not HTML that's returned.

Also, I fixed a minor bug if the fetch follows any redirects.  That could be pretty common for any shortened URL (e.g. bit.ly) and would mess up many of the image URL's that are returned (both in getImages and getFavicons).

I added some tests and updated the README as well.

Let me know your thoughts on any changes.  And thanks again!

Best,
Steve
