### PR TITLE
Handle newlines at the end of the string

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -25,7 +25,8 @@ describe('link preview', () => {
   });
 
   it('should extract link info from a URL with a newline', async () => {
-    const linkInfo = await LinkPreview.getPreview(`https://www.youtube.com/watch?v=wuClZjOdT30
+    const linkInfo = await LinkPreview.getPreview(`
+      https://www.youtube.com/watch?v=wuClZjOdT30
     `);
     // { url: 'https://www.youtube.com/watch?v=wuClZjOdT30',
     //   title: 'Geography Now! Germany - YouTube',

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -24,6 +24,27 @@ describe('link preview', () => {
     expect(linkInfo.contentType.toLowerCase()).to.be.equal('text/html; charset=utf-8');
   });
 
+  it('should extract link info from a URL with a newline', async () => {
+    const linkInfo = await LinkPreview.getPreview(`https://www.youtube.com/watch?v=wuClZjOdT30
+    `);
+    // { url: 'https://www.youtube.com/watch?v=wuClZjOdT30',
+    //   title: 'Geography Now! Germany - YouTube',
+    //   description: 'Gluten free vegetarians beware. Watch at your own risk. We now have a Public mailbox! Feel free to send anything via mail! Our public mailbox address is: 190...',
+    //   mediaType: 'video',
+    //   images: [ 'https://i.ytimg.com/vi/wuClZjOdT30/maxresdefault.jpg' ],
+    //   videos: undefined }
+
+    expect(linkInfo.url).to.be.equal('https://www.youtube.com/watch?v=wuClZjOdT30');
+    expect(linkInfo.title).to.be.equal('Geography Now! Germany');
+    expect(linkInfo.description).to.be.ok();
+    expect(linkInfo.mediaType).to.be.equal('video.other');
+    expect(linkInfo.images.length).to.be.equal(1);
+    expect(linkInfo.images[0]).to.be.equal('https://i.ytimg.com/vi/wuClZjOdT30/maxresdefault.jpg');
+    expect(linkInfo.videos.length).to.be.equal(0);
+    expect(linkInfo.favicons[0]).to.be.equal('https://www.youtube.com/yts/img/favicon_32-vflOogEID.png');
+    expect(linkInfo.contentType.toLowerCase()).to.be.equal('text/html; charset=utf-8');
+  });
+
   it('should extract link info from just text with a URL', async () => {
     const linkInfo = await LinkPreview.getPreview('This is some text blah blah https://www.youtube.com/watch?v=wuClZjOdT30 and more text');
     // { url: 'https://www.youtube.com/watch?v=wuClZjOdT30',

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ exports.getPreview = function(text, options) {
 
     let detectedUrl = null;
 
-    text.replace('\n', ' ').split(' ').forEach(token => {
+    text.replace(/\n/g, ' ').split(' ').forEach(token => {
       if (REGEX_VALID_URL.test(token) && !detectedUrl) {
         detectedUrl = token;
       }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ exports.getPreview = function(text, options) {
 
     let detectedUrl = null;
 
-    text.split(' ').forEach(token => {
+    text.replace('\n', ' ').split(' ').forEach(token => {
       if (REGEX_VALID_URL.test(token) && !detectedUrl) {
         detectedUrl = token;
       }


### PR DESCRIPTION
Fixes https://github.com/ospfranco/react-native-link-preview/issues/27

This replaces all the newlines in the text with single spaces prior to parsing.

### Rejected ideas:
- **modify the regex to capture newlines:** not ideal as then the captured url would also include the newline
- **replace newlines with an empty string:** would fail in the edge case where the link is followed by a newline with text
